### PR TITLE
Add time-delta-scaling to bullet animations

### DIFF
--- a/BismarkUnchained/scenes/Bullet/Body.gd
+++ b/BismarkUnchained/scenes/Bullet/Body.gd
@@ -7,9 +7,9 @@ func _physics_process(delta):
 	rotation = velocity.angle()
 	
 	# move and check for a collision
-	var kc = move_and_collide(velocity * delta)
+	var kc = move_and_collide(velocity * get_node("/root/Main").time_delta * delta)
 	if kc:
 		if kc.collider.has_method('damage'):
 			kc.collider.damage()
-		get_parent().explode()
+		get_parent().explode(kc.position)
 		queue_free()

--- a/BismarkUnchained/scenes/Bullet/Bullet.gd
+++ b/BismarkUnchained/scenes/Bullet/Bullet.gd
@@ -1,10 +1,19 @@
 extends Node2D
 
-func explode():
-	$Explosion.global_position = get_node('Body').global_position
+var time_left = 0
+
+func explode(pos):
+	$Explosion.global_position = pos
 	$Explosion.emitting = true
-	$FreeTimer.connect('timeout', self, 'queue_free')
-	$FreeTimer.start()
+	
+	# allow time for all particles to expire before destroying
+	time_left = $Explosion.lifetime * 1.5
+
+func _process(delta):
+	if $Explosion.emitting and time_left < 0:
+		queue_free()
+	$Explosion.speed_scale = get_node("/root/Main").time_delta
+	time_left -= delta * get_node("/root/Main").time_delta
 
 # vel is a Vector2
 func init(vel):

--- a/BismarkUnchained/scenes/Bullet/Bullet.gd
+++ b/BismarkUnchained/scenes/Bullet/Bullet.gd
@@ -13,13 +13,13 @@ func explode(pos):
 func _process(delta):
 	if has_node('Body'):
 		$Afterburner.global_position = $Body.global_position - Vector2(7, 0)
-		$Afterburner.speed_scale = get_node("/root/Main").time_delta
+		$Afterburner.speed_scale = get_node("/root/Main").get_time_delta()
 	else:
 		if time_left < 0:
 			queue_free()
 		else:
-			$Explosion.speed_scale = get_node("/root/Main").time_delta
-			time_left -= delta * get_node("/root/Main").time_delta
+			$Explosion.speed_scale = get_node("/root/Main").get_time_delta()
+			time_left -= delta * get_node("/root/Main").get_time_delta()
 
 # vel is a Vector2
 func init(vel):

--- a/BismarkUnchained/scenes/Bullet/Bullet.gd
+++ b/BismarkUnchained/scenes/Bullet/Bullet.gd
@@ -5,15 +5,21 @@ var time_left = 0
 func explode(pos):
 	$Explosion.global_position = pos
 	$Explosion.emitting = true
+	$Afterburner.emitting = false
 	
 	# allow time for all particles to expire before destroying
 	time_left = $Explosion.lifetime * 1.5
 
 func _process(delta):
-	if $Explosion.emitting and time_left < 0:
-		queue_free()
-	$Explosion.speed_scale = get_node("/root/Main").time_delta
-	time_left -= delta * get_node("/root/Main").time_delta
+	if has_node('Body'):
+		$Afterburner.global_position = $Body.global_position - Vector2(7, 0)
+		$Afterburner.speed_scale = get_node("/root/Main").time_delta
+	else:
+		if time_left < 0:
+			queue_free()
+		else:
+			$Explosion.speed_scale = get_node("/root/Main").time_delta
+			time_left -= delta * get_node("/root/Main").time_delta
 
 # vel is a Vector2
 func init(vel):

--- a/BismarkUnchained/scenes/Bullet/Bullet.tscn
+++ b/BismarkUnchained/scenes/Bullet/Bullet.tscn
@@ -3,7 +3,7 @@
 [ext_resource path="res://scenes/Bullet/Bullet.gd" type="Script" id=1]
 [ext_resource path="res://scenes/Bullet/Body.gd" type="Script" id=2]
 
-[sub_resource type="CapsuleShape2D" id=1]
+[sub_resource type="CapsuleShape2D" id=6]
 radius = 2.0
 height = 10.0
 
@@ -41,7 +41,8 @@ script = ExtResource( 2 )
 
 [node name="CollisionShape" type="CollisionShape2D" parent="Body"]
 rotation = 1.5708
-shape = SubResource( 1 )
+shape = SubResource( 6 )
+one_way_collision = true
 
 [node name="Mesh" type="Node2D" parent="Body"]
 editor/display_folded = true
@@ -62,13 +63,9 @@ position = Vector2( -7, 0 )
 process_material = SubResource( 4 )
 
 [node name="Explosion" type="Particles2D" parent="."]
-position = Vector2( 7, 0 )
 emitting = false
-amount = 500
+amount = 250
 lifetime = 0.5
 one_shot = true
-explosiveness = 0.5
+explosiveness = 0.8
 process_material = SubResource( 5 )
-
-[node name="FreeTimer" type="Timer" parent="."]
-one_shot = true

--- a/BismarkUnchained/scenes/Bullet/Bullet.tscn
+++ b/BismarkUnchained/scenes/Bullet/Bullet.tscn
@@ -14,15 +14,6 @@ size = Vector3( 10, 4, 2 )
 radius = 2.0
 height = 4.0
 
-[sub_resource type="ParticlesMaterial" id=4]
-emission_shape = 2
-emission_box_extents = Vector3( 5, 5, 1 )
-flag_disable_z = true
-gravity = Vector3( -89, 0, 0 )
-orbit_velocity = 0.0
-orbit_velocity_random = 0.0
-color = Color( 1, 0, 0, 1 )
-
 [sub_resource type="ParticlesMaterial" id=5]
 emission_shape = 1
 emission_sphere_radius = 2.0
@@ -32,6 +23,15 @@ gravity = Vector3( 0, 0, 0 )
 initial_velocity = 100.0
 orbit_velocity = 0.0
 orbit_velocity_random = 0.0
+
+[sub_resource type="ParticlesMaterial" id=4]
+emission_shape = 1
+emission_sphere_radius = 1.5
+flag_disable_z = true
+gravity = Vector3( -89, 0, 0 )
+orbit_velocity = 0.0
+orbit_velocity_random = 0.0
+color = Color( 1, 0, 0, 1 )
 
 [node name="Bullet" type="Node2D"]
 script = ExtResource( 1 )
@@ -58,10 +58,6 @@ mesh = SubResource( 3 )
 position = Vector2( -5, 0 )
 mesh = SubResource( 3 )
 
-[node name="Afterburner" type="Particles2D" parent="Body"]
-position = Vector2( -7, 0 )
-process_material = SubResource( 4 )
-
 [node name="Explosion" type="Particles2D" parent="."]
 emitting = false
 amount = 250
@@ -69,3 +65,8 @@ lifetime = 0.5
 one_shot = true
 explosiveness = 0.8
 process_material = SubResource( 5 )
+
+[node name="Afterburner" type="Particles2D" parent="."]
+lifetime = 0.5
+local_coords = false
+process_material = SubResource( 4 )


### PR DESCRIPTION
1) properly scales bullet explosion (and destruction timing) with `time_delta`
2) fixes collision - so you can't ride the back of a bullet - by enabling `one_way_collision`
3) scales afterburner particles with `time_delta`
4) afterburner particles stop emitting after explosion, but are destroyed as if they were separate entities