### PR TITLE
Add mines and fix/improve bullet mechanics

### DIFF
--- a/BismarkUnchained/scenes/Enemy/Enemy.gd
+++ b/BismarkUnchained/scenes/Enemy/Enemy.gd
@@ -31,7 +31,7 @@ func _process(delta):
 	
 	if get_angle_to(player_pos) < 0.5 && get_angle_to(player_pos) > -0.5 && time_left < 0 && player_pos.distance_to(pos) > 150:
 		var s = sprite.instance()
-		s.get_node("Body").velocity = Vector2(player_pos.x - pos.x, player_pos.y - pos.y).normalized() * 100
+		s.set_bullet_velocity(Vector2(player_pos.x - pos.x, player_pos.y - pos.y).normalized() * 100)
 		get_parent().add_child(s)
 		s.global_position = Vector2(pos.x - .4 * (pos.x - player_pos.x) / 2, pos.y - .4 * (pos.y - player_pos.y) / 2)
 		time_left = .5

--- a/BismarkUnchained/scenes/Enemy/Enemy.gd
+++ b/BismarkUnchained/scenes/Enemy/Enemy.gd
@@ -2,6 +2,7 @@ extends KinematicBody2D
 
 onready var sprite = preload("res://scenes/Weapons/Bullet/Bullet.tscn")
 
+const is_enemy = true
 const aim_speed = deg2rad(1) * 3.2
 
 var time_left = 0
@@ -31,6 +32,7 @@ func _process(delta):
 	
 	if get_angle_to(player_pos) < 0.5 && get_angle_to(player_pos) > -0.5 && time_left < 0 && player_pos.distance_to(pos) > 150:
 		var s = sprite.instance()
+		s.set_can_damage_enemy(false)
 		s.set_bullet_velocity(Vector2(player_pos.x - pos.x, player_pos.y - pos.y).normalized() * 100)
 		get_parent().add_child(s)
 		s.global_position = Vector2(pos.x - .4 * (pos.x - player_pos.x) / 2, pos.y - .4 * (pos.y - player_pos.y) / 2)

--- a/BismarkUnchained/scenes/Weapons/Bullet/Body.gd
+++ b/BismarkUnchained/scenes/Weapons/Bullet/Body.gd
@@ -1,13 +1,23 @@
 extends KinematicBody2D
 
+const max_rotation_radians_per_sec = deg2rad(180)
+
 var velocity = Vector2(100, 0)
+var homing_object = null
 
 func _ready():
 	rotation = velocity.angle()
 
 func _physics_process(delta):
+	if homing_object:
+		var dir = get_global_position().direction_to(homing_object.get_global_position())
+		var angle = dir.angle_to(velocity.normalized())
+		var phi = min(max_rotation_radians_per_sec, abs(angle)) * delta
+		velocity = velocity.rotated(-phi if angle > 0 else phi)
+	
 	# Rotation should always be locked to velocity
 	rotation = velocity.angle()
+	get_node("../Afterburner").global_position = get_global_position() - velocity.normalized() * 7
 	
 	# Move and check for a collision
 	var collision = move_and_collide(velocity * get_node("/root/Main").time_delta * delta)

--- a/BismarkUnchained/scenes/Weapons/Bullet/Body.gd
+++ b/BismarkUnchained/scenes/Weapons/Bullet/Body.gd
@@ -4,6 +4,7 @@ const max_rotation_radians_per_sec = deg2rad(180)
 
 var velocity = Vector2(100, 0)
 var homing_object = null
+var can_damage_enemy = true
 
 func _ready():
 	rotation = velocity.angle()
@@ -22,7 +23,14 @@ func _physics_process(delta):
 	# Move and check for a collision
 	var collision = move_and_collide(velocity * get_node("/root/Main").time_delta * delta)
 	if collision:
-		if collision.collider.has_method('damage'):
+		# If bullet cannot damage enemies and collider is an enemy, don't damage
+		var damage = true
+		if !can_damage_enemy:
+			var is_enemy = collision.collider.get('is_enemy')
+			if is_enemy != null && is_enemy:
+				damage = false
+		
+		if damage && collision.collider.has_method('damage'):
 			collision.collider.damage()
 		get_parent().explode(collision.position)
 		queue_free()

--- a/BismarkUnchained/scenes/Weapons/Bullet/Bullet.gd
+++ b/BismarkUnchained/scenes/Weapons/Bullet/Bullet.gd
@@ -1,6 +1,7 @@
 extends Node2D
 
 var time_left = 0
+var velocity = Vector2(0, 0)
 
 func explode(pos):
 	$Explosion.global_position = pos
@@ -12,7 +13,7 @@ func explode(pos):
 
 func _process(delta):
 	if has_node('Body'):
-		$Afterburner.global_position = $Body.global_position - Vector2(7, 0)
+		$Afterburner.global_position = $Body.global_position - velocity.normalized() * 7
 		$Afterburner.speed_scale = get_node("/root/Main").get_time_delta()
 	else:
 		if time_left < 0:
@@ -21,5 +22,6 @@ func _process(delta):
 			$Explosion.speed_scale = get_node("/root/Main").get_time_delta()
 			time_left -= delta * get_node("/root/Main").get_time_delta()
 
-func set_bullet_velocity(velocity):
-	$Body.velocity = velocity
+func set_bullet_velocity(vel):
+	velocity = vel
+	$Body.velocity = vel

--- a/BismarkUnchained/scenes/Weapons/Bullet/Bullet.gd
+++ b/BismarkUnchained/scenes/Weapons/Bullet/Bullet.gd
@@ -13,7 +13,6 @@ func explode(pos):
 
 func _process(delta):
 	if has_node('Body'):
-		$Afterburner.global_position = $Body.global_position - velocity.normalized() * 7
 		$Afterburner.speed_scale = get_node("/root/Main").get_time_delta()
 	else:
 		if time_left < 0:
@@ -21,6 +20,9 @@ func _process(delta):
 		else:
 			$Explosion.speed_scale = get_node("/root/Main").get_time_delta()
 			time_left -= delta * get_node("/root/Main").get_time_delta()
+
+func set_bullet_object_to_home(object):
+	$Body.homing_object = object
 
 func set_bullet_velocity(vel):
 	velocity = vel

--- a/BismarkUnchained/scenes/Weapons/Bullet/Bullet.gd
+++ b/BismarkUnchained/scenes/Weapons/Bullet/Bullet.gd
@@ -21,6 +21,9 @@ func _process(delta):
 			$Explosion.speed_scale = get_node("/root/Main").get_time_delta()
 			time_left -= delta * get_node("/root/Main").get_time_delta()
 
+func set_can_damage_enemy(can_damage):
+	$Body.can_damage_enemy = can_damage
+
 func set_bullet_object_to_home(object):
 	$Body.homing_object = object
 

--- a/BismarkUnchained/scenes/Weapons/Bullet/Bullet.tscn
+++ b/BismarkUnchained/scenes/Weapons/Bullet/Bullet.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=8 format=2]
+[gd_scene load_steps=9 format=2]
 
 [ext_resource path="res://scenes/Weapons/Bullet/Bullet.gd" type="Script" id=1]
 [ext_resource path="res://scenes/Weapons/Bullet/Body.gd" type="Script" id=2]
@@ -14,6 +14,8 @@ size = Vector3( 10, 4, 2 )
 radius = 2.0
 height = 4.0
 
+[sub_resource type="CubeMesh" id=6]
+
 [sub_resource type="ParticlesMaterial" id=4]
 emission_shape = 1
 emission_sphere_radius = 2.0
@@ -21,6 +23,7 @@ flag_disable_z = true
 spread = 180.0
 gravity = Vector3( 0, 0, 0 )
 initial_velocity = 100.0
+angular_velocity = 1.0
 orbit_velocity = 0.0
 orbit_velocity_random = 0.0
 
@@ -28,7 +31,9 @@ orbit_velocity_random = 0.0
 emission_shape = 1
 emission_sphere_radius = 1.5
 flag_disable_z = true
-gravity = Vector3( -89, 0, 0 )
+spread = 180.0
+gravity = Vector3( 0, 0, 0 )
+initial_velocity = 5.0
 orbit_velocity = 0.0
 orbit_velocity_random = 0.0
 color = Color( 1, 0, 0, 1 )
@@ -45,7 +50,6 @@ shape = SubResource( 1 )
 one_way_collision = true
 
 [node name="Mesh" type="Node2D" parent="Body"]
-editor/display_folded = true
 
 [node name="CenterMesh" type="MeshInstance2D" parent="Body/Mesh"]
 mesh = SubResource( 2 )
@@ -57,6 +61,10 @@ mesh = SubResource( 3 )
 [node name="LeftMesh" type="MeshInstance2D" parent="Body/Mesh"]
 position = Vector2( -5, 0 )
 mesh = SubResource( 3 )
+
+[node name="Front" type="MeshInstance2D" parent="Body/Mesh"]
+position = Vector2( 7, 0 )
+mesh = SubResource( 6 )
 
 [node name="Explosion" type="Particles2D" parent="."]
 emitting = false

--- a/BismarkUnchained/scenes/Weapons/Bullet/Bullet.tscn
+++ b/BismarkUnchained/scenes/Weapons/Bullet/Bullet.tscn
@@ -42,6 +42,7 @@ color = Color( 1, 0, 0, 1 )
 script = ExtResource( 1 )
 
 [node name="Body" type="KinematicBody2D" parent="."]
+collision_mask = 2
 script = ExtResource( 2 )
 
 [node name="CollisionShape" type="CollisionShape2D" parent="Body"]

--- a/BismarkUnchained/scenes/Weapons/Bullet/Bullet.tscn
+++ b/BismarkUnchained/scenes/Weapons/Bullet/Bullet.tscn
@@ -3,8 +3,6 @@
 [ext_resource path="res://scenes/Weapons/Bullet/Bullet.gd" type="Script" id=1]
 [ext_resource path="res://scenes/Weapons/Bullet/Body.gd" type="Script" id=2]
 
-
-
 [sub_resource type="CapsuleShape2D" id=1]
 radius = 2.0
 height = 10.0

--- a/BismarkUnchained/scenes/Weapons/Bullet/Bullet.tscn
+++ b/BismarkUnchained/scenes/Weapons/Bullet/Bullet.tscn
@@ -14,9 +14,9 @@ size = Vector3( 10, 4, 2 )
 radius = 2.0
 height = 4.0
 
-[sub_resource type="CubeMesh" id=6]
+[sub_resource type="CubeMesh" id=4]
 
-[sub_resource type="ParticlesMaterial" id=4]
+[sub_resource type="ParticlesMaterial" id=5]
 emission_shape = 1
 emission_sphere_radius = 2.0
 flag_disable_z = true
@@ -27,7 +27,7 @@ angular_velocity = 1.0
 orbit_velocity = 0.0
 orbit_velocity_random = 0.0
 
-[sub_resource type="ParticlesMaterial" id=5]
+[sub_resource type="ParticlesMaterial" id=6]
 emission_shape = 1
 emission_sphere_radius = 1.5
 flag_disable_z = true
@@ -64,7 +64,7 @@ mesh = SubResource( 3 )
 
 [node name="Front" type="MeshInstance2D" parent="Body/Mesh"]
 position = Vector2( 7, 0 )
-mesh = SubResource( 6 )
+mesh = SubResource( 4 )
 
 [node name="Explosion" type="Particles2D" parent="."]
 emitting = false
@@ -72,9 +72,9 @@ amount = 250
 lifetime = 0.5
 one_shot = true
 explosiveness = 0.8
-process_material = SubResource( 4 )
+process_material = SubResource( 5 )
 
 [node name="Afterburner" type="Particles2D" parent="."]
 lifetime = 0.5
 local_coords = false
-process_material = SubResource( 5 )
+process_material = SubResource( 6 )

--- a/BismarkUnchained/scenes/Weapons/BulletMine/BulletMine.gd
+++ b/BismarkUnchained/scenes/Weapons/BulletMine/BulletMine.gd
@@ -1,0 +1,41 @@
+extends Node2D
+
+onready var bullet_scene = preload("res://scenes/Weapons/Bullet/Bullet.tscn")
+onready var start = get_node("/root/Main").time_elapsed
+
+var was_warning = false
+var warnings = 4 # tick, tick, tick, tick/BOOM
+
+func generate_spawn_locations():
+	# (x, y) = offset/direction from mine's location
+	# z = velocity
+	return [
+				Vector3(10, 0, 100),
+				Vector3(-10, 10, 100),
+				Vector3(10, -10, 100),
+				Vector3(-10, -10, 100)
+			]
+
+func spawn_bullets():
+	for spawn in generate_spawn_locations():
+		var dir = Vector2(spawn.x, spawn.y)
+		var bullet = bullet_scene.instance()
+		bullet.set_bullet_velocity(dir.normalized() * spawn.z)
+		get_parent().add_child(bullet)
+		bullet.global_position = get_global_position() + dir
+
+func _process(delta):
+	var time_elapsed_delta = get_node("/root/Main").time_elapsed - start
+	var r = (1 + sin(8 * time_elapsed_delta)) / 2
+	if r >= .98 && !was_warning:
+		# tick
+		warnings -= 1
+		was_warning = true
+	elif was_warning && r < .98:
+		was_warning = false
+	$Body.set_modulate(Color(r, 0, 0))
+	#$Body.set_scale(Vector2(r, r))
+	if warnings == 0:
+		# BOOM
+		spawn_bullets()
+		queue_free()

--- a/BismarkUnchained/scenes/Weapons/BulletMine/BulletMine.tscn
+++ b/BismarkUnchained/scenes/Weapons/BulletMine/BulletMine.tscn
@@ -1,0 +1,20 @@
+[gd_scene load_steps=4 format=2]
+
+[ext_resource path="res://scenes/Weapons/BulletMine/BulletMine.gd" type="Script" id=1]
+
+[sub_resource type="CircleShape2D" id=1]
+
+[sub_resource type="SphereMesh" id=2]
+radius = 10.0
+height = 20.0
+
+[node name="BulletMine" type="Node2D"]
+script = ExtResource( 1 )
+
+[node name="Body" type="StaticBody2D" parent="."]
+
+[node name="CollisionShape" type="CollisionShape2D" parent="Body"]
+shape = SubResource( 1 )
+
+[node name="Mesh" type="MeshInstance2D" parent="Body"]
+mesh = SubResource( 2 )

--- a/BismarkUnchained/scenes/Weapons/ImpulseMine/ImpulseMine.gd
+++ b/BismarkUnchained/scenes/Weapons/ImpulseMine/ImpulseMine.gd
@@ -1,0 +1,44 @@
+extends Node2D
+
+onready var bullet_scene = preload("res://scenes/Weapons/Bullet/Bullet.tscn")
+onready var start = get_node("/root/Main").time_elapsed
+
+const impulse_minimum_radius = 10
+const impulse_maximum_radius = 50
+
+var was_warning = false
+var warnings = 4 # tick, tick, tick, tick/BOOM
+
+func scale_impulse_strength(dist):
+	return (impulse_maximum_radius - dist) / (impulse_maximum_radius - impulse_minimum_radius)
+
+func impulse_objects():
+	var shape = CircleShape2D.new()
+	shape.set_radius(impulse_maximum_radius)
+	
+	var query = Physics2DShapeQueryParameters.new()
+	query.set_shape(shape)
+	query.set_transform($Body.get_global_transform())
+	query.set_exclude([$Body])
+	var impulsed_objects = get_world_2d().get_direct_space_state().intersect_shape(query, 32)
+	for obj in impulsed_objects:
+		if obj.collider.has_method('impulse'):
+			var dir = get_global_position().direction_to(obj.collider.get_global_position())
+			var dist = get_global_position().distance_to(obj.collider.get_global_position())
+			obj.collider.impulse(dir.normalized(), scale_impulse_strength(dist))
+
+func _process(delta):
+	var time_elapsed_delta = get_node("/root/Main").time_elapsed - start
+	var b = (1 + sin(8 * time_elapsed_delta)) / 2
+	if b >= .98 && !was_warning:
+		# tick
+		warnings -= 1
+		was_warning = true
+	elif was_warning && b < .98:
+		was_warning = false
+	$Body.set_modulate(Color(0, 0, b))
+	#$Body.set_scale(Vector2(b, b))
+	if warnings == 0:
+		# BOOM
+		impulse_objects()
+		queue_free()

--- a/BismarkUnchained/scenes/Weapons/ImpulseMine/ImpulseMine.tscn
+++ b/BismarkUnchained/scenes/Weapons/ImpulseMine/ImpulseMine.tscn
@@ -1,0 +1,20 @@
+[gd_scene load_steps=4 format=2]
+
+[ext_resource path="res://scenes/Weapons/ImpulseMine/ImpulseMine.gd" type="Script" id=1]
+
+[sub_resource type="CircleShape2D" id=1]
+
+[sub_resource type="SphereMesh" id=2]
+radius = 10.0
+height = 20.0
+
+[node name="ImpulseMine" type="Node2D"]
+script = ExtResource( 1 )
+
+[node name="Body" type="StaticBody2D" parent="."]
+
+[node name="CollisionShape" type="CollisionShape2D" parent="Body"]
+shape = SubResource( 1 )
+
+[node name="Mesh" type="MeshInstance2D" parent="Body"]
+mesh = SubResource( 2 )

--- a/BismarkUnchained/scenes/Weapons/Laser/Laser.gd
+++ b/BismarkUnchained/scenes/Weapons/Laser/Laser.gd
@@ -1,0 +1,49 @@
+extends Node2D
+
+const lase_warmup_time = 3
+const lase_time = .1
+
+var warming_up = true
+var time_left = lase_warmup_time
+
+func set_laser_direction(dir):
+	# $MeshInstance2D.scale.x = velocity.length()
+	rotate(dir.angle())
+
+func calc_laser_collisions():
+	var shape = RectangleShape2D.new()
+	shape.set_extents(Vector2(5, 100))
+	
+	var query = Physics2DShapeQueryParameters.new()
+	query.set_shape(shape)
+	query.set_transform($MeshInstance2D.get_global_transform())
+	query.set_exclude([self])
+	return get_world_2d().get_direct_space_state().intersect_shape(query, 32)
+
+func _physics_process(delta):
+	if time_left > 0:
+		var scaled_delta = delta * get_node("/root/Main").get_time_delta()
+		if warming_up:
+			var ratio_remain = time_left / lase_warmup_time
+			if ratio_remain > .66:
+				$ParticlesLeft.emitting = true
+			elif ratio_remain > .33:
+				$ParticlesRight.emitting = true
+			else:
+				$ParticlesCenter.emitting = true
+			$ParticlesLeft.speed_scale = get_node("/root/Main").get_time_delta()
+			$ParticlesRight.speed_scale = get_node("/root/Main").get_time_delta()
+			$ParticlesCenter.speed_scale = get_node("/root/Main").get_time_delta()
+		else:
+			$MeshInstance2D.scale.y = 1 - time_left / lase_time
+		time_left -= scaled_delta
+	else:
+		if warming_up:
+			warming_up = false
+			time_left = lase_time
+		else:
+			var list = calc_laser_collisions()
+			for i in list:
+				if i.collider.has_method('damage'):
+					i.collider.damage()
+			queue_free()

--- a/BismarkUnchained/scenes/Weapons/Laser/Laser.gd
+++ b/BismarkUnchained/scenes/Weapons/Laser/Laser.gd
@@ -17,7 +17,7 @@ func calc_laser_collisions():
 	var query = Physics2DShapeQueryParameters.new()
 	query.set_shape(shape)
 	query.set_transform($MeshInstance2D.get_global_transform())
-	query.set_exclude([self])
+	query.set_exclude([$Mesh, $ParticlesLeft, $ParticlesCenter, $ParticlesRight])
 	return get_world_2d().get_direct_space_state().intersect_shape(query, 32)
 
 func _physics_process(delta):

--- a/BismarkUnchained/scenes/Weapons/Laser/Laser.tscn
+++ b/BismarkUnchained/scenes/Weapons/Laser/Laser.tscn
@@ -17,7 +17,7 @@ orbit_velocity_random = 0.0
 [node name="Laser" type="Node2D"]
 script = ExtResource( 1 )
 
-[node name="MeshInstance2D" type="MeshInstance2D" parent="."]
+[node name="Mesh" type="MeshInstance2D" parent="."]
 position = Vector2( 100, 0 )
 scale = Vector2( 1, 1e-005 )
 mesh = SubResource( 1 )

--- a/BismarkUnchained/scenes/Weapons/Laser/Laser.tscn
+++ b/BismarkUnchained/scenes/Weapons/Laser/Laser.tscn
@@ -1,0 +1,40 @@
+[gd_scene load_steps=4 format=2]
+
+[ext_resource path="res://scenes/Weapons/Laser/Laser.gd" type="Script" id=1]
+
+[sub_resource type="QuadMesh" id=1]
+size = Vector2( 200, 10 )
+
+[sub_resource type="ParticlesMaterial" id=2]
+flag_disable_z = true
+spread = 180.0
+gravity = Vector3( 0, 0, 0 )
+initial_velocity = 50.0
+angular_velocity = 1.0
+orbit_velocity = 0.0
+orbit_velocity_random = 0.0
+
+[node name="Laser" type="Node2D"]
+script = ExtResource( 1 )
+
+[node name="MeshInstance2D" type="MeshInstance2D" parent="."]
+position = Vector2( 100, 0 )
+scale = Vector2( 1, 1e-005 )
+mesh = SubResource( 1 )
+
+[node name="ParticlesLeft" type="Particles2D" parent="."]
+position = Vector2( 10, -15 )
+emitting = false
+lifetime = 0.1
+process_material = SubResource( 2 )
+
+[node name="ParticlesRight" type="Particles2D" parent="."]
+position = Vector2( 10, 15 )
+emitting = false
+lifetime = 0.1
+process_material = SubResource( 2 )
+
+[node name="ParticlesCenter" type="Particles2D" parent="."]
+emitting = false
+lifetime = 0.1
+process_material = SubResource( 2 )


### PR DESCRIPTION
WIP but:
- fixes bullet afterburner, locks rotation to velocity
- adds ImpulseMine
- adds BulletMine
- adds Laser (needs animation help)
- replaces bullet velocity access with `set_bullet_velocity`
- the bullet scene now has a `set_bullet_object_to_home` (shitty name I know) that makes bullets start homing towards the `get_global_position()` of whatever objects is passed to it (or null)

notes:
- laser is placed and forgotten, I thought having the laser rotate with the player would allow for too much damage (bc you can rotate infinitely fast)
- ImpulseMine calls the `impulse(direction, strength)` function on any objects within its impulse, so we need to implement that for any objects we want to make impulse-able
- the number of bullets spawned by a BulletMine should scale with 1) player skill tree or 2) enemy difficulty depending on who deploys it

related: #51 #46 